### PR TITLE
fix(pool): return this compile's CSS, not the previous one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fixes
+- **A compile returned the PREVIOUS compile's CSS.** `Pool.compile/2` started
+  the CLI before writing the operation's content, so the run that produced the
+  output had compiled whatever was already on disk; the caller then accepted
+  that file because the pool's `last_output_mtime` baseline was recorded after
+  that same run. The result was an off-by-one reported as success — content A
+  compiled, then A's output returned for content B — and, in a fresh OS
+  process, an output file left by an earlier run returned as if it were this
+  one's result. Content is now staged (and the baseline taken) before any port
+  exists.
+- **Ports started without `--watch` are no longer reused.** That CLI compiles
+  once and exits, so a second operation on the same pooled port had nothing to
+  rewrite its output: the wait ran to timeout and returned the earlier artifact
+  as `readiness: :degraded`. Non-watch ports are now retired after use and a
+  fresh run is started; watch-mode ports stay poolable, which is what the pool
+  is for.
+
 ## [0.3.6] - 2026-07-11
 
 ### ✨ Features

--- a/lib/defdo/tailwind_port/pool.ex
+++ b/lib/defdo/tailwind_port/pool.ex
@@ -152,6 +152,12 @@ defmodule Defdo.TailwindPort.Pool do
       }
     )
 
+    # Stage the operation's content BEFORE any port exists. Starting the port
+    # runs the CLI immediately against whatever is on disk, so writing the
+    # content afterwards means the run that produces the output compiled the
+    # PREVIOUS content — the caller gets a stale artifact reported as success.
+    normalized_operation = stage_operation(normalized_operation)
+
     case find_or_create_port(config_hash, normalized_operation.opts, state) do
       {:ok, port_info, new_state} ->
         case execute_compilation(port_info, normalized_operation, new_state) do
@@ -367,6 +373,14 @@ defmodule Defdo.TailwindPort.Pool do
 
   defp find_or_create_port(config_hash, opts, state) do
     case Map.get(state.port_pool, config_hash) do
+      # A CLI started without --watch compiles once and exits. Reusing that
+      # port cannot produce a new artifact: nothing rewrites the output, the
+      # wait times out, and the previous compile's CSS comes back as this
+      # one's result. Retire it and start a run that can see the new content.
+      # Watch-mode ports stay poolable — that is what they are for.
+      %{status: :idle, watch?: false} = port_info ->
+        create_new_port(config_hash, opts, retire_port(config_hash, port_info, state))
+
       %{status: :idle} = port_info ->
         # Reuse existing idle port
         updated_port_info = %{
@@ -436,7 +450,8 @@ defmodule Defdo.TailwindPort.Pool do
           last_used: System.monotonic_time(:millisecond),
           status: :busy,
           build_count: 0,
-          created_at: System.monotonic_time(:millisecond)
+          created_at: System.monotonic_time(:millisecond),
+          watch?: watch_mode?(opts)
         }
 
         port_info = initialize_port_metadata(port_info, opts)
@@ -479,7 +494,8 @@ defmodule Defdo.TailwindPort.Pool do
           last_used: System.monotonic_time(:millisecond),
           status: :busy,
           build_count: 0,
-          created_at: System.monotonic_time(:millisecond)
+          created_at: System.monotonic_time(:millisecond),
+          watch?: watch_mode?(opts)
         }
 
         existing_info = initialize_port_metadata(existing_info, opts)
@@ -549,11 +565,12 @@ defmodule Defdo.TailwindPort.Pool do
   defp perform_compilation(port_info, operation, state, readiness) do
     with {:ok, port_info, state} <- ensure_fs_state(port_info, state, operation),
          {:ok, working_paths} <- prepare_working_files(port_info),
-         :ok <- write_operation_content(working_paths, operation.content) do
+         :ok <- maybe_write_operation_content(working_paths, operation) do
       case fallback_to_file_based_capture(
              port_info,
              working_paths,
-             state.options
+             state.options,
+             baseline_mtime(port_info, operation)
            ) do
         {:ok, build_info} ->
           finalize_compilation(port_info, state, readiness, build_info, operation)
@@ -632,6 +649,42 @@ defmodule Defdo.TailwindPort.Pool do
     end
   end
 
+  # Writes the operation's content and records what the output file looked like
+  # BEFORE anything could recompile it. Both halves matter:
+  #
+  #   * the content has to be on disk before the CLI starts, or the startup run
+  #     compiles the previous operation's content;
+  #   * the baseline has to be taken before that run, or "the output changed"
+  #     is measured against the very file the stale run just wrote.
+  #
+  # Failures here are not fatal: the port path re-creates directories and can
+  # still write the content itself, so staging degrades to the old behaviour
+  # rather than failing the compile.
+  defp stage_operation(operation) do
+    paths = build_port_paths(operation.opts)
+    content_path = primary_content_path(paths)
+
+    baseline =
+      with path when is_binary(path) <- content_path,
+           :ok <- ensure_directory(path),
+           :ok <- ensure_directory(paths[:output_path]),
+           :ok <- ensure_directory(paths[:input_path]),
+           :ok <- File.write(path, operation.content) do
+        file_mtime(paths[:output_path])
+      else
+        _ -> :unstaged
+      end
+
+    Map.put(operation, :staged_baseline, baseline)
+  end
+
+  defp primary_content_path(paths) do
+    case select_primary_content_path(paths[:content_paths]) do
+      {:ok, path} -> path
+      _ -> paths[:input_path]
+    end
+  end
+
   defp prepare_working_files(%{paths: paths}) do
     case Map.get(paths, :primary_content_path) do
       nil ->
@@ -647,14 +700,30 @@ defmodule Defdo.TailwindPort.Pool do
     end
   end
 
-  defp write_operation_content(%{content_path: content_path}, content) do
-    File.write(content_path, content)
+  # Staging already wrote the content; rewriting it here would only re-trigger
+  # a watcher for no reason. When staging could not run, this is still the one
+  # place the content reaches disk.
+  defp maybe_write_operation_content(_working_paths, %{staged_baseline: baseline})
+       when baseline != :unstaged,
+       do: :ok
+
+  defp maybe_write_operation_content(%{content_path: content_path}, operation) do
+    File.write(content_path, operation.content)
   end
 
+  # The staged baseline is what the output looked like before this operation's
+  # content existed. `last_output_mtime` is not a substitute: it is recorded
+  # after the port starts, so it already describes the stale run's output.
+  defp baseline_mtime(port_info, %{staged_baseline: :unstaged}),
+    do: Map.get(port_info, :last_output_mtime)
+
+  defp baseline_mtime(_port_info, %{staged_baseline: baseline}), do: baseline
+
+  defp baseline_mtime(port_info, _operation), do: Map.get(port_info, :last_output_mtime)
+
   # Fallback to original file-based capture when immediate capture fails
-  defp fallback_to_file_based_capture(port_info, working_paths, options) do
+  defp fallback_to_file_based_capture(port_info, working_paths, options, previous_mtime) do
     output_path = working_paths.output_path
-    previous_mtime = Map.get(port_info, :last_output_mtime)
     timeout_ms = Keyword.get(options, :compile_timeout_ms, 5_000)
 
     if is_nil(output_path) do
@@ -850,6 +919,28 @@ defmodule Defdo.TailwindPort.Pool do
     else
       Logger.info("Tailwind process #{inspect(pid)} went down: #{inspect(reason)}")
       %{state | port_pool: Map.new(kept), stats: new_stats}
+    end
+  end
+
+  # Drops a spent port from the pool and stops its process. The monitor goes
+  # first so the resulting :DOWN does not arrive as an unexplained port death.
+  defp retire_port(config_hash, port_info, state) do
+    demonitor_port(port_info)
+
+    if is_pid(port_info[:pid]) and Process.alive?(port_info[:pid]) do
+      GenServer.stop(port_info[:pid], :normal, 1_000)
+    end
+
+    %{state | port_pool: Map.delete(state.port_pool, config_hash)}
+  catch
+    :exit, _reason -> %{state | port_pool: Map.delete(state.port_pool, config_hash)}
+  end
+
+  defp watch_mode?(opts) do
+    case Keyword.get(opts, :watch) do
+      nil -> false
+      false -> false
+      _ -> true
     end
   end
 

--- a/test/pool_staleness_test.exs
+++ b/test/pool_staleness_test.exs
@@ -1,0 +1,73 @@
+defmodule Defdo.TailwindPort.PoolStalenessTest do
+  # async: false — the pool is a named singleton.
+  use ExUnit.Case, async: false
+
+  alias Defdo.TailwindPort.Pool
+
+  @moduletag :tmp_dir
+
+  # A stand-in for the Tailwind CLI: same `-i input -o output` contract, and it
+  # copies the input to the output so a compile's result is traceable back to
+  # the content that produced it. Prints the "Done in" line the readiness
+  # detector looks for.
+  defp fake_cli(dir) do
+    path = Path.join(dir, "fake_tailwind")
+
+    File.write!(path, """
+    #!/bin/sh
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -i) IN="$2"; shift 2 ;;
+        -o) OUT="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cat "$IN" > "$OUT"
+    echo "Done in 1ms"
+    """)
+
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  setup %{tmp_dir: dir} do
+    {:ok, _pid} = Pool.start_link(compile_timeout_ms: 3_000, port_ready_timeout: 3_000)
+
+    opts = [
+      cmd: fake_cli(dir),
+      input: Path.join(dir, "in.css"),
+      output: Path.join(dir, "out.css"),
+      content: Path.join(dir, "in.css")
+    ]
+
+    {:ok, opts: opts}
+  end
+
+  test "a compile returns ITS content, not the previous one", %{opts: opts} do
+    # The regression: the pool started the CLI before writing the operation's
+    # content, so the run that produced the output had compiled whatever was on
+    # disk from last time. The first compile returned an empty/stale artifact
+    # and the second returned the first one's — an off-by-one that reads as
+    # success, and in production shipped a skin one edit behind.
+    assert {:ok, first} = Pool.compile(opts, ".first {}")
+    assert first.compiled_css =~ ".first {}"
+
+    assert {:ok, second} = Pool.compile(opts, ".second {}")
+    assert second.compiled_css =~ ".second {}"
+    refute second.compiled_css =~ ".first {}"
+
+    assert {:ok, third} = Pool.compile(opts, ".third {}")
+    assert third.compiled_css =~ ".third {}"
+  end
+
+  test "a stale output file left by an earlier run is not returned", %{opts: opts, tmp_dir: dir} do
+    # The pool is fresh in every OS process, so `last_output_mtime` starts nil
+    # and any pre-existing output file looked like a valid result.
+    File.write!(Path.join(dir, "out.css"), ".from-a-previous-process {}")
+
+    assert {:ok, result} = Pool.compile(opts, ".current {}")
+
+    assert result.compiled_css =~ ".current {}"
+    refute result.compiled_css =~ ".from-a-previous-process {}"
+  end
+end


### PR DESCRIPTION
## The defect

`Pool.compile/2` had a deterministic off-by-one — not a race.

`handle_call({:compile, ...})` called `find_or_create_port/3` **first**. That starts the Tailwind CLI immediately against whatever `-i` points at. Only afterwards did `perform_compilation/4` write the operation's content. So the run that produced the output had compiled the **previous** content.

The caller then accepted that output, because `initialize_port_metadata/2` records `last_output_mtime` *after* the port starts — the "has the output changed" baseline already described the stale run's own file.

Two visible shapes, both reported as success:

1. Content A compiled → A's output returned as **B's** result.
2. In a fresh OS process (pool state empty, output path derived from a stable config hash) an output file **left by an earlier run** returned as this compile's result.

Found from the consuming side, in `defdo_status`: adding a custom CSS sheet to a theme, compiling, and getting the pre-sheet artifact back byte for byte. The next compile returned the right one — which is what makes it look like flakiness rather than ordering.

## Second half of the same bug

A CLI started without `--watch` compiles once and exits. Reusing that pooled port could not produce a new artifact at all: nothing rewrote the output, `await_file_update/3` ran to timeout, and the earlier CSS came back flagged `readiness: :degraded`. That flag was the only trace, and it reads as "slow", not "wrong".

## The fix

- `stage_operation/1` writes the operation's content and takes the output baseline **before any port exists**. If staging cannot run it returns `:unstaged` and the original write path still applies — this degrades, it does not fail.
- Non-watch ports are retired after use (`retire_port/3`) and a fresh run is started. Watch-mode ports stay poolable, which is what the pool is actually for.
- `fallback_to_file_based_capture/4` takes the baseline explicitly instead of reading the port's post-start value.

## Verification

- New `test/pool_staleness_test.exs` covers both shapes with a stub CLI that copies input to output, so a result is traceable to the content that produced it. **Both cases fail on the previous code** (verified by stashing the fix).
- Full suite: **416 tests, 0 failures**
- `mix credo --strict` clean, `mix format --check-formatted` clean