### PR TITLE
fix(pool): stop reporting results the pool never produced (0.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.7] - 2026-08-05
 
 ### 🐛 Fixes
 - **A compile returned the PREVIOUS compile's CSS.** `Pool.compile/2` started
   the CLI before writing the operation's content, so the run that produced the
   output had compiled whatever was already on disk; the caller then accepted
-  that file because the pool's `last_output_mtime` baseline was recorded after
-  that same run. The result was an off-by-one reported as success — content A
-  compiled, then A's output returned for content B — and, in a fresh OS
-  process, an output file left by an earlier run returned as if it were this
-  one's result. Content is now staged (and the baseline taken) before any port
-  exists.
+  that file because the freshness baseline was recorded after that same run.
+  Content is now staged — and the previous artifact removed — before any port
+  exists, so the output's reappearance is the evidence it belongs to this
+  operation.
 - **Ports started without `--watch` are no longer reused.** That CLI compiles
   once and exits, so a second operation on the same pooled port had nothing to
   rewrite its output: the wait ran to timeout and returned the earlier artifact
-  as `readiness: :degraded`. Non-watch ports are now retired after use and a
-  fresh run is started; watch-mode ports stay poolable, which is what the pool
-  is for.
+  as `readiness: :degraded`. Non-watch ports are retired after use; watch-mode
+  ports stay poolable.
+- **`batch_compile/1` fabricated its results.** It wrote no content, ran no
+  CLI, waited on no file, and returned `compiled_css: "/tmp/batch_output_<ref>.css"`
+  — a path to a file that was never created — while incrementing build counts
+  and compilation totals. Every operation now goes through the real compile
+  path; entries are `{:ok, result}` or `{:error, reason, id}`.
+- **A failed capture returned the caller's own content as `compiled_css`.**
+  `fallback_css/2` ended in `operation.content`, so a caller could be handed
+  back the HTML it asked to compile, labelled as a stylesheet. Missing output
+  is now `{:error, :no_compiled_output}`, which also covers the empty string
+  every fallback strategy returns when it finds nothing (`""` is a binary, so
+  it used to pass as a successful compile).
+- **A timeout is an error, not a degraded success.** The deadline branch read
+  the output file unconditionally and returned its contents, with no evidence
+  they belonged to this operation.
+- **Freshness no longer depends on mtime.** `File.stat/2` reports whole
+  seconds, so two builds inside one second were indistinguishable — reachable
+  on any watch-mode port rebuilding shortly after the previous build. Output
+  is also required to be byte-identical across two consecutive reads, since
+  Tailwind truncates the file before writing and a read could land mid-write.
+
+### ⚙️ Changed
+- `compile_timeout_ms` default 5s → 20s. A cold Tailwind v4 run over a real
+  project takes several seconds; at 5s those compiles hit the deadline every
+  time, and a deadline now fails instead of quietly returning stale CSS.
 
 ## [0.3.6] - 2026-07-11
 

--- a/lib/defdo/tailwind_port/pool.ex
+++ b/lib/defdo/tailwind_port/pool.ex
@@ -117,18 +117,6 @@ defmodule Defdo.TailwindPort.Pool do
     {:ok, state}
   end
 
-  defp process_operation_group(config_hash, ops, acc_results, acc_state) do
-    case find_or_create_port(config_hash, hd(ops).opts, acc_state) do
-      {:ok, port_info, new_state} ->
-        {batch_results, batch_state} = execute_batch_compilation(port_info, ops, new_state)
-        {acc_results ++ batch_results, batch_state}
-
-      {:error, _reason} ->
-        error_results = Enum.map(ops, fn op -> {:error, :port_unavailable, op.id} end)
-        {acc_results ++ error_results, acc_state}
-    end
-  end
-
   @impl true
   def handle_call({:compile, operation}, _from, state) do
     start_time = System.monotonic_time(:microsecond)
@@ -227,20 +215,25 @@ defmodule Defdo.TailwindPort.Pool do
 
   @impl true
   def handle_call({:batch_compile, operations}, _from, state) do
-    # Group operations by configuration for efficiency
-    normalized_ops =
-      Enum.map(operations, fn op ->
-        Map.update!(op, :opts, &normalize_operation_opts(&1, state.options))
-      end)
-
-    grouped_ops = group_operations_by_config(normalized_ops)
-
+    # Each operation goes through the real compile path. The previous
+    # implementation grouped operations by config and then SIMULATED them:
+    # `execute_batch_compilation/3` wrote no content, ran no CLI, waited on no
+    # file, and returned `compiled_css: "/tmp/batch_output_<ref>.css"` — a path
+    # to a file that was never created — while incrementing build counts and
+    # compilation totals. Every caller was told a batch had compiled.
+    #
+    # Operations still share pooled ports when their configs match; that is
+    # what the pool is for. What they no longer share is the pretence.
     {results, final_state} =
-      Enum.reduce(grouped_ops, {[], state}, fn {config_hash, ops}, {acc_results, acc_state} ->
-        process_operation_group(config_hash, ops, acc_results, acc_state)
+      Enum.reduce(operations, {[], state}, fn operation, {acc, acc_state} ->
+        {result, next_state} = compile_operation(operation, acc_state)
+        {[result | acc], next_state}
       end)
 
-    updated_stats = update_stats(final_state.stats, :batch_compile, length(operations))
+    results = Enum.reverse(results)
+    compiled = Enum.count(results, &match?({:ok, _}, &1))
+
+    updated_stats = update_stats(final_state.stats, :batch_compile, compiled)
     {:reply, {:ok, results}, %{final_state | stats: updated_stats}}
   end
 
@@ -587,36 +580,6 @@ defmodule Defdo.TailwindPort.Pool do
     end
   end
 
-  defp execute_batch_compilation(port_info, operations, state) do
-    # Execute multiple operations on the same port efficiently
-    {results, final_port_info} =
-      Enum.reduce(operations, {[], port_info}, fn operation, {acc_results, acc_port_info} ->
-        # Simulate batch execution - in real implementation,
-        # this would optimize file writing and port communication
-        result = %{
-          compiled_css: "/tmp/batch_output_#{operation.id}.css",
-          port: acc_port_info.port,
-          operation_id: operation.id
-        }
-
-        updated_port_info = %{acc_port_info | build_count: acc_port_info.build_count + 1}
-
-        {[result | acc_results], updated_port_info}
-      end)
-
-    # Update port info in pool
-    final_port_info = %{
-      final_port_info
-      | status: :idle,
-        last_used: System.monotonic_time(:millisecond)
-    }
-
-    updated_pool = Map.put(state.port_pool, port_info.config_hash, final_port_info)
-    new_state = %{state | port_pool: updated_pool}
-
-    {Enum.reverse(results), new_state}
-  end
-
   defp ensure_fs_state(port_info, state, operation) do
     updated_port_info =
       if Map.has_key?(port_info, :paths) do
@@ -649,6 +612,27 @@ defmodule Defdo.TailwindPort.Pool do
     end
   end
 
+  # One operation, start to finish, against the same state the caller holds.
+  defp compile_operation(operation, state) do
+    normalized =
+      operation
+      |> Map.update!(:opts, &normalize_operation_opts(&1, state.options))
+      |> stage_operation()
+
+    config_hash = hash_config(normalized.opts)
+
+    case find_or_create_port(config_hash, normalized.opts, state) do
+      {:ok, port_info, new_state} ->
+        case execute_compilation(port_info, normalized, new_state) do
+          {:ok, result, final_state} -> {{:ok, result}, final_state}
+          {:error, reason, final_state} -> {{:error, reason, operation.id}, final_state}
+        end
+
+      {:error, reason} ->
+        {{:error, reason, operation.id}, state}
+    end
+  end
+
   # Writes the operation's content and records what the output file looked like
   # BEFORE anything could recompile it. Both halves matter:
   #
@@ -670,7 +654,13 @@ defmodule Defdo.TailwindPort.Pool do
            :ok <- ensure_directory(paths[:output_path]),
            :ok <- ensure_directory(paths[:input_path]),
            :ok <- File.write(path, operation.content) do
-        file_mtime(paths[:output_path])
+        # Remove the previous artifact so its REAPPEARANCE is the proof this
+        # run produced it. Comparing content instead would call a legitimate
+        # recompile of unchanged input "no change" — identical bytes are the
+        # normal case, not a symptom — and comparing mtime cannot see two
+        # builds inside one second, since `File.stat/2` reports whole seconds.
+        File.rm(paths[:output_path])
+        :absent
       else
         _ -> :unstaged
       end
@@ -712,14 +702,15 @@ defmodule Defdo.TailwindPort.Pool do
   end
 
   # The staged baseline is what the output looked like before this operation's
-  # content existed. `last_output_mtime` is not a substitute: it is recorded
+  # content existed. The port's own record is not a substitute: it is taken
   # after the port starts, so it already describes the stale run's output.
   defp baseline_mtime(port_info, %{staged_baseline: :unstaged}),
-    do: Map.get(port_info, :last_output_mtime)
+    do: Map.get(port_info, :last_output_fingerprint, :absent)
 
   defp baseline_mtime(_port_info, %{staged_baseline: baseline}), do: baseline
 
-  defp baseline_mtime(port_info, _operation), do: Map.get(port_info, :last_output_mtime)
+  defp baseline_mtime(port_info, _operation),
+    do: Map.get(port_info, :last_output_fingerprint, :absent)
 
   # Fallback to original file-based capture when immediate capture fails
   defp fallback_to_file_based_capture(port_info, working_paths, options, previous_mtime) do
@@ -767,6 +758,19 @@ defmodule Defdo.TailwindPort.Pool do
           fallback_css(port_info, operation)
       end
 
+    finalize_with_css(css, port_info, state, readiness, build_info, operation)
+  end
+
+  # No artifact is a failure. It used to be a success carrying `""` (the empty
+  # string every fallback strategy returns when it finds nothing, and a binary,
+  # so it passed the `is_binary/1` check above) or the caller's own content.
+  # Both shapes told the caller a stylesheet had been produced.
+  defp finalize_with_css(css, _port_info, state, _readiness, _build_info, _operation)
+       when css in [nil, ""] do
+    {:error, :no_compiled_output, state}
+  end
+
+  defp finalize_with_css(css, port_info, state, readiness, build_info, operation) do
     result = %{
       compiled_css: css,
       output_path: build_info[:output_path],
@@ -781,13 +785,13 @@ defmodule Defdo.TailwindPort.Pool do
       |> Map.update(:build_count, 1, &(&1 + 1))
       |> Map.put(:last_used, System.monotonic_time(:millisecond))
       |> Map.put(:last_output_mtime, build_info[:new_mtime] || port_info[:last_output_mtime])
+      |> Map.put(
+        :last_output_fingerprint,
+        build_info[:fingerprint] || port_info[:last_output_fingerprint] || :absent
+      )
 
     updated_pool = Map.put(state.port_pool, port_info.config_hash, updated_port_info)
     {:ok, result, %{state | port_pool: updated_pool}}
-  end
-
-  defp group_operations_by_config(operations) do
-    Enum.group_by(operations, fn op -> hash_config(op.opts) end)
   end
 
   defp hash_config(opts) do
@@ -1270,6 +1274,7 @@ defmodule Defdo.TailwindPort.Pool do
     port_info
     |> Map.put(:paths, paths)
     |> Map.put(:last_output_mtime, file_mtime(paths[:output_path]))
+    |> Map.put(:last_output_fingerprint, file_fingerprint(paths[:output_path]))
   end
 
   defp build_port_paths(opts) do
@@ -1329,61 +1334,60 @@ defmodule Defdo.TailwindPort.Pool do
     end
   end
 
-  defp await_file_update(path, previous_mtime, timeout_ms) do
+  # Waits for the artifact this operation produced.
+  #
+  # Staging removed the previous output, so its reappearance is the evidence.
+  # The old test — `mtime > previous` — could not provide any: `File.stat/2`
+  # reports whole seconds, so two builds inside one second are identical to
+  # it, which a watch-mode port rebuilding 200ms later hits every time.
+  #
+  # Stability, not first sight: Tailwind truncates the file before writing it,
+  # so a read can land mid-write. Content has to match across two consecutive
+  # reads before it counts as finished.
+  #
+  # Timing out is an error, not a degraded success. Returning the file as-is
+  # was the same defect in another place: no evidence it belongs to this
+  # operation, reported as `{:ok, ...}`.
+  defp await_file_update(path, baseline, timeout_ms) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_await_file_update(path, previous_mtime, deadline)
+    do_await_file_update(path, baseline, deadline, nil)
   end
 
-  defp do_await_file_update(path, previous_mtime, deadline) do
-    now = System.monotonic_time(:millisecond)
-
-    if now >= deadline do
-      case read_output_file(path) do
-        {:ok, css, mtime} ->
-          {:degraded,
-           %{
-             css: css,
-             output_path: path,
-             new_mtime: mtime,
-             reason: :timeout
-           }}
-
-        {:error, _} ->
-          {:degraded,
-           %{
-             css: nil,
-             output_path: path,
-             new_mtime: previous_mtime,
-             reason: :timeout
-           }}
-      end
+  defp do_await_file_update(path, baseline, deadline, candidate) do
+    if System.monotonic_time(:millisecond) >= deadline do
+      {:error, :compile_timeout}
     else
-      handle_file_read_result(path, previous_mtime, deadline)
+      handle_file_read_result(path, baseline, deadline, candidate)
     end
   end
 
-  defp handle_file_read_result(path, previous_mtime, deadline) do
+  defp handle_file_read_result(path, baseline, deadline, candidate) do
     case read_output_file(path) do
       {:ok, css, mtime} ->
-        if previous_mtime == nil or mtime > previous_mtime do
-          {:ok,
-           %{
-             css: css,
-             output_path: path,
-             new_mtime: mtime
-           }}
-        else
-          Process.sleep(75)
-          do_await_file_update(path, previous_mtime, deadline)
+        fingerprint = fingerprint(css, mtime)
+
+        cond do
+          fingerprint == baseline ->
+            retry_await(path, baseline, deadline, nil)
+
+          fingerprint == candidate ->
+            {:ok, %{css: css, output_path: path, new_mtime: mtime, fingerprint: fingerprint}}
+
+          true ->
+            retry_await(path, baseline, deadline, fingerprint)
         end
 
       {:error, :enoent} ->
-        Process.sleep(75)
-        do_await_file_update(path, previous_mtime, deadline)
+        retry_await(path, baseline, deadline, nil)
 
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp retry_await(path, baseline, deadline, candidate) do
+    Process.sleep(75)
+    do_await_file_update(path, baseline, deadline, candidate)
   end
 
   defp read_output_file(path) do
@@ -1396,6 +1400,18 @@ defmodule Defdo.TailwindPort.Pool do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # The identity of an output file: what it says, not when it was touched.
+  defp fingerprint(css, mtime), do: {mtime, byte_size(css), :erlang.md5(css)}
+
+  defp file_fingerprint(nil), do: :absent
+
+  defp file_fingerprint(path) do
+    case read_output_file(path) do
+      {:ok, css, mtime} -> fingerprint(css, mtime)
+      {:error, _reason} -> :absent
     end
   end
 
@@ -1589,8 +1605,13 @@ defmodule Defdo.TailwindPort.Pool do
       nil
   end
 
-  defp fallback_css(port_info, operation) do
-    fetch_latest_output(port_info.pid) || operation.content
+  # The caller's own content is NOT a compile result. Returning it here meant
+  # `{:ok, %{compiled_css: "<div class='...'>"}}` — the HTML that was supposed
+  # to be compiled, handed back as the stylesheet. Whatever the port preserved
+  # from an earlier build is at least CSS, but it is not this operation's, so
+  # it is only ever a degraded answer; when there is nothing, say so.
+  defp fallback_css(port_info, _operation) do
+    fetch_latest_output(port_info.pid)
   end
 
   defp default_options do
@@ -1600,7 +1621,12 @@ defmodule Defdo.TailwindPort.Pool do
       enable_batching: true,
       cleanup_interval: @port_idle_timeout,
       baseline_compilation_time_ms: nil,
-      compile_timeout_ms: 5_000
+      # A cold Tailwind v4 run over a real project takes multiple seconds —
+      # ~6s for a themed app here. At 5s those compiles hit the deadline every
+      # time, and a deadline used to return the previous artifact as success;
+      # now it is an error, so the old default would turn working builds into
+      # failures. Still well under the 30s `GenServer.call` timeout.
+      compile_timeout_ms: 20_000
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule TailwindPort.MixProject do
   def project do
     [
       app: :tailwind_port,
-      version: "0.3.6",
+      version: "0.3.7",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/defdo/tailwind_port_health_test.exs
+++ b/test/defdo/tailwind_port_health_test.exs
@@ -96,7 +96,11 @@ defmodule Defdo.TailwindPortHealthTest do
     path
   end
 
-  defp wait_for(fun, attempts \\ 20)
+  # 2s, not 500ms: this waits for an OS process to start and exit, and the
+  # suite now runs real CLI stubs elsewhere, so the box can be busy enough for
+  # a 500ms budget to expire before the exit is reaped. The assertion is about
+  # the eventual exit status, never about how quickly it arrives.
+  defp wait_for(fun, attempts \\ 80)
 
   defp wait_for(fun, attempts) when attempts > 0 do
     if fun.() do

--- a/test/pool_test.exs
+++ b/test/pool_test.exs
@@ -3,6 +3,32 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   alias Defdo.TailwindPort.Pool
 
+  # A stand-in for the Tailwind CLI. `echo` used to serve this purpose, but it
+  # writes no output file — so these tests only passed while the pool invented
+  # a result for a compile that never happened. This honours the `-i/-o`
+  # contract and prints the "Done in" line readiness detection looks for.
+  @cli Path.join(System.tmp_dir!(), "tailwind_port_pool_test/fake_tailwind")
+
+  setup_all do
+    File.mkdir_p!(Path.dirname(@cli))
+
+    File.write!(@cli, """
+    #!/bin/sh
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -i) IN="$2"; shift 2 ;;
+        -o) OUT="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [ -n "$OUT" ] && { [ -f "$IN" ] && cat "$IN" > "$OUT" || echo "/* empty */" > "$OUT"; }
+    echo "Done in 1ms"
+    """)
+
+    File.chmod!(@cli, 0o755)
+    :ok
+  end
+
   setup do
     # Ensure clean state before each test
     case Process.whereis(Pool) do
@@ -15,32 +41,32 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "start_link/1" do
     test "starts the pooled port pool successfully" do
-      assert {:ok, pid} = Pool.start_link(compile_timeout_ms: 100)
+      assert {:ok, pid} = Pool.start_link(compile_timeout_ms: 2_000)
       assert Process.alive?(pid)
       assert Process.whereis(Pool) == pid
     end
 
     test "returns already_started if already running" do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       assert {:error, {:already_started, _pid}} = Pool.start_link()
     end
 
     test "accepts custom options" do
       opts = [max_pool_size: 5, enable_watch_mode: false]
-      assert {:ok, _pid} = Pool.start_link([compile_timeout_ms: 100] ++ opts)
+      assert {:ok, _pid} = Pool.start_link([compile_timeout_ms: 2_000] ++ opts)
     end
   end
 
   describe "compile/2" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
     test "compiles successfully with valid options" do
       opts = [
         # Use echo for testing
-        cmd: "echo",
+        cmd: @cli,
         input: "/tmp/test_input.css",
         output: "/tmp/test_output.css",
         content: "/tmp/test_content.html"
@@ -70,7 +96,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
     test "reuses ports for identical configurations" do
       opts = [
-        cmd: "echo",
+        cmd: @cli,
         input: "/tmp/test_input.css",
         output: "/tmp/test_output.css"
       ]
@@ -92,7 +118,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "batch_compile/1" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
@@ -100,13 +126,23 @@ defmodule Defdo.TailwindPort.PoolTest do
       operations = [
         %{
           id: :op1,
-          opts: [cmd: "echo", input: "/tmp/input1.css", output: "/tmp/output1.css"],
+          opts: [
+            cmd: @cli,
+            input: "/tmp/input1.css",
+            output: "/tmp/output1.css",
+            content: "/tmp/input1.css"
+          ],
           content: "<div class='bg-blue-500'>Test 1</div>",
           priority: :normal
         },
         %{
           id: :op2,
-          opts: [cmd: "echo", input: "/tmp/input2.css", output: "/tmp/output2.css"],
+          opts: [
+            cmd: @cli,
+            input: "/tmp/input2.css",
+            output: "/tmp/output2.css",
+            content: "/tmp/input2.css"
+          ],
           content: "<div class='bg-green-500'>Test 2</div>",
           priority: :high
         }
@@ -116,10 +152,15 @@ defmodule Defdo.TailwindPort.PoolTest do
       assert is_list(results)
       assert length(results) == 2
 
-      # Verify each result has the operation_id
-      operation_ids = Enum.map(results, & &1.operation_id)
-      assert :op1 in operation_ids
-      assert :op2 in operation_ids
+      # Each entry is the outcome of a real compile, tagged {:ok, result} or
+      # {:error, reason, id}. It used to be a fabricated map naming an output
+      # file that was never written.
+      assert [{:ok, first}, {:ok, second}] = results
+      assert Enum.sort([first.operation_id, second.operation_id]) == [:op1, :op2]
+
+      # The content each operation asked for actually reached the compiler.
+      assert first.compiled_css =~ "bg-blue-500"
+      assert second.compiled_css =~ "bg-green-500"
     end
 
     test "groups operations by configuration for efficiency" do
@@ -127,13 +168,13 @@ defmodule Defdo.TailwindPort.PoolTest do
       same_config_ops = [
         %{
           id: :same1,
-          opts: [cmd: "echo", input: "/tmp/same.css"],
+          opts: [cmd: @cli, input: "/tmp/same.css"],
           content: "<div>1</div>",
           priority: :normal
         },
         %{
           id: :same2,
-          opts: [cmd: "echo", input: "/tmp/same.css"],
+          opts: [cmd: @cli, input: "/tmp/same.css"],
           content: "<div>2</div>",
           priority: :normal
         }
@@ -154,7 +195,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "get_stats/0" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
@@ -187,7 +228,7 @@ defmodule Defdo.TailwindPort.PoolTest do
     test "tracks compilation counts correctly" do
       initial_stats = Pool.get_stats()
 
-      opts = [cmd: "echo", input: "/tmp/test.css"]
+      opts = [cmd: @cli, input: "/tmp/test.css"]
       content = "<div>Test</div>"
 
       {:ok, _result} = Pool.compile(opts, content)
@@ -199,14 +240,14 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "warm_up/1" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
     test "pre-creates ports for common configurations" do
       common_configs = [
-        [cmd: "echo", input: "/tmp/common1.css"],
-        [cmd: "echo", input: "/tmp/common2.css"]
+        [cmd: @cli, input: "/tmp/common1.css"],
+        [cmd: @cli, input: "/tmp/common2.css"]
       ]
 
       :ok = Pool.warm_up(common_configs)
@@ -231,17 +272,17 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "port pool management" do
     setup do
-      {:ok, _pid} = Pool.start_link(max_pool_size: 2, compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(max_pool_size: 2, compile_timeout_ms: 2_000)
       :ok
     end
 
     test "respects max pool size" do
       # Try to create more ports than max_pool_size
       opts_list = [
-        [cmd: "echo", input: "/tmp/test1.css"],
-        [cmd: "echo", input: "/tmp/test2.css"],
+        [cmd: @cli, input: "/tmp/test1.css"],
+        [cmd: @cli, input: "/tmp/test2.css"],
         # Should exceed max_pool_size of 2
-        [cmd: "echo", input: "/tmp/test3.css"]
+        [cmd: @cli, input: "/tmp/test3.css"]
       ]
 
       content = "<div>Test</div>"
@@ -259,7 +300,7 @@ defmodule Defdo.TailwindPort.PoolTest do
     end
 
     test "cleans up idle ports" do
-      opts = [cmd: "echo", input: "/tmp/idle_test.css"]
+      opts = [cmd: @cli, input: "/tmp/idle_test.css"]
       content = "<div>Test</div>"
 
       {:ok, _result} = Pool.compile(opts, content)
@@ -279,7 +320,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "error handling and recovery" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
@@ -301,7 +342,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
     test "recovers from port exits" do
       # This test would simulate a port crashing
-      opts = [cmd: "echo", input: "/tmp/test.css"]
+      opts = [cmd: @cli, input: "/tmp/test.css"]
       content = "<div>Test</div>"
 
       {:ok, _result} = Pool.compile(opts, content)
@@ -318,7 +359,7 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "telemetry integration" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
 
       # Attach test telemetry handler
       test_pid = self()
@@ -346,7 +387,7 @@ defmodule Defdo.TailwindPort.PoolTest do
     end
 
     test "emits telemetry events for compilations" do
-      opts = [cmd: "echo", input: "/tmp/telemetry_test.css"]
+      opts = [cmd: @cli, input: "/tmp/telemetry_test.css"]
       content = "<div>Test</div>"
 
       {:ok, _result} = Pool.compile(opts, content)
@@ -367,7 +408,7 @@ defmodule Defdo.TailwindPort.PoolTest do
     end
 
     test "emits pool management events" do
-      opts = [cmd: "echo", input: "/tmp/pool_test.css"]
+      opts = [cmd: @cli, input: "/tmp/pool_test.css"]
       content = "<div>Test</div>"
 
       # First compilation should create port
@@ -385,13 +426,13 @@ defmodule Defdo.TailwindPort.PoolTest do
 
   describe "configuration hashing" do
     setup do
-      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 100)
+      {:ok, _pid} = Pool.start_link(compile_timeout_ms: 2_000)
       :ok
     end
 
     test "identical configurations produce same hash" do
-      opts1 = [cmd: "echo", input: "/tmp/same.css", output: "/tmp/out.css"]
-      opts2 = [cmd: "echo", input: "/tmp/same.css", output: "/tmp/out.css"]
+      opts1 = [cmd: @cli, input: "/tmp/same.css", output: "/tmp/out.css"]
+      opts2 = [cmd: @cli, input: "/tmp/same.css", output: "/tmp/out.css"]
 
       content = "<div>Test</div>"
 
@@ -404,8 +445,8 @@ defmodule Defdo.TailwindPort.PoolTest do
     end
 
     test "different configurations produce different hashes" do
-      opts1 = [cmd: "echo", input: "/tmp/different1.css"]
-      opts2 = [cmd: "echo", input: "/tmp/different2.css"]
+      opts1 = [cmd: @cli, input: "/tmp/different1.css"]
+      opts2 = [cmd: @cli, input: "/tmp/different2.css"]
 
       content = "<div>Test</div>"
 


### PR DESCRIPTION
Follow-up to #21. I audited the pool for the same failure family — **a success result that is not the product of the current operation** — and found four more, two of them worse than the ordering bug.

## What was wrong

| | |
|---|---|
| **`batch_compile/1` compiled nothing** | `execute_batch_compilation/3` wrote no content, started no CLI, waited on no file. It returned `compiled_css: "/tmp/batch_output_<ref>.css"` — a *path* to a file that was never created — and incremented build counts and compilation totals. A caller writing that into a `<style>` tag shipped the literal string. |
| **`fallback_css/2` returned the caller's own HTML** | It ended in `operation.content`, so `{:ok, %{compiled_css: "<div class='bg-blue-500'>"}}` was a reachable result. And every fallback strategy returns `""` when it finds nothing — `""` is a binary, so it passed the `is_binary/1` check and became the compile result too. |
| **Timeout returned the output file unconditionally** | The deadline branch read whatever was on disk and returned it as a degraded success, with no evidence it belonged to this operation. |
| **Freshness rested on mtime** | `File.stat/2` reports whole **seconds**, so two builds inside one second are indistinguishable. Reachable on any watch-mode port rebuilding shortly after the previous build — precisely the port class #21 keeps poolable. |

## The fix

- Staging **removes the previous artifact**, so the output's reappearance is the evidence. This also handles the ordinary case #21's approach could not: a recompile of unchanged input produces byte-identical CSS, which no content comparison can distinguish from "nothing happened".
- Output must be **stable across two consecutive reads** — Tailwind truncates before writing, so a read can land mid-write.
- Missing output is `{:error, :no_compiled_output}`; a timeout is `{:error, :compile_timeout}`.
- `batch_compile/1` runs the real compile path per operation; entries are `{:ok, result}` or `{:error, reason, id}`.
- **`compile_timeout_ms` default 5s → 20s.** A cold Tailwind v4 run over a real project takes several seconds (~6s for a themed app). At 5s those compiles hit the deadline every time — which mattered little when a deadline quietly returned stale CSS, and matters a lot now that it fails.

## Tests

The pool tests used `cmd: "echo"`, which writes no output file — they passed only because the pool invented a result. They now run a stub CLI honouring `-i/-o`, and the batch test asserts each operation's content actually reached the compiler rather than counting list entries.

Also widened a 500ms wait in `tailwind_port_health_test` to 2s: it waits for an OS process to start and exit, and the suite now runs real CLI stubs, so the box gets busy enough for that budget to expire (seed 222 caught it). The assertion is about the eventual exit status, not its latency.

## Verification

- **416 tests, 0 failures**; re-run across seeds 111/222/333/444/555 clean after the timing fix
- `mix credo --strict` clean, `mix format --check-formatted` clean
- **End to end against `defdo_status` with the real Tailwind CLI**: the first compile after a theme edit now returns that edit (27347 bytes, chrome present, no `degraded` warning) where it previously returned the pre-edit artifact.

Version bumped to **0.3.7** with the changelog entry, ready to tag on merge.